### PR TITLE
Add string overload to LookupUsersAsync

### DIFF
--- a/osu.NET/Endpoints/Users.cs
+++ b/osu.NET/Endpoints/Users.cs
@@ -274,7 +274,7 @@ public partial class OsuApiClient
   public async Task<ApiResult<User[]>> LookupUsersAsync(string[] ids, bool? excludeBots = null, CancellationToken? cancellationToken = null)
     => await GetAsync<User[]>($"users/lookup", cancellationToken,
     [
-      .. ids.Select(x => ("ids[]", x)),
+      .. ids.Select(x => ("ids[]", Uri.EscapeDataString(x))),
       ("exclude_bots", excludeBots)
     ], json => json["users"]);
 }

--- a/osu.NET/Endpoints/Users.cs
+++ b/osu.NET/Endpoints/Users.cs
@@ -250,26 +250,26 @@ public partial class OsuApiClient
       ("exclude_bots", excludeBots)
     ], json => json["users"]);
 
-  /// <summary>
-  /// Returns all users with the specified IDs, up to 50. If a user ID could not be found, it is skipped.
-  /// <br/><br/>
-  /// This endpoint does not include any statistics. If you need this information,
-  /// use <see cref="GetUsersAsync(int[], bool?, CancellationToken?)"/> with a higher ratelimit cost.
-  /// <br/><br/>
-  /// API notes:
-  /// <list type="bullet">
-  /// <item>Includes <see cref="User.Country"/></item>
-  /// <item>Includes <see cref="User.Cover"/></item>
-  /// <item>Includes <see cref="User.Groups"/></item>
-  /// <item>Does *not* include <see cref="User.Statistics"/> or <see cref="User.RulesetStatistics"/></item>
-  /// </list>
-  /// API docs:<br/>
-  /// <a href="https://osu.ppy.sh/docs/index.html#get-users"/>
-  /// </summary>
-  /// <param name="ids">The user IDs.</param>
-  /// <param name="excludeBots">Optional. Bool whether bot users should be ignored.</param>
-  /// <param name="cancellationToken">Optional. The cancellation token for aborting the request.</param>
-  /// <returns>The users with the specified IDs.</returns>
+/// <summary>
+/// Returns all users with the specified usernames, up to 50. If a username could not be found, it is skipped.
+/// <br/><br/>
+/// This endpoint does not include any statistics. If you need this information,
+/// use <see cref="GetUsersAsync(int[], bool?, CancellationToken?)"/> with a higher ratelimit cost.
+/// <br/><br/>
+/// API notes:
+/// <list type="bullet">
+/// <item>Includes <see cref="User.Country"/></item>
+/// <item>Includes <see cref="User.Cover"/></item>
+/// <item>Includes <see cref="User.Groups"/></item>
+/// <item>Does *not* include <see cref="User.Statistics"/> or <see cref="User.RulesetStatistics"/></item>
+/// </list>
+/// API docs:<br/>
+/// <a href="https://osu.ppy.sh/docs/index.html#get-users"/>
+/// </summary>
+/// <param name="usernames">The usernames.</param>
+/// <param name="excludeBots">Optional. Bool whether bot users should be ignored.</param>
+/// <param name="cancellationToken">Optional. The cancellation token for aborting the request.</param>
+/// <returns>The users with the specified names.</returns>
   [CanReturnApiError()]
   public async Task<ApiResult<User[]>> LookupUsersAsync(string[] ids, bool? excludeBots = null, CancellationToken? cancellationToken = null)
     => await GetAsync<User[]>($"users/lookup", cancellationToken,

--- a/osu.NET/Endpoints/Users.cs
+++ b/osu.NET/Endpoints/Users.cs
@@ -274,7 +274,7 @@ public partial class OsuApiClient
   public async Task<ApiResult<User[]>> LookupUsersAsync(string[] ids, bool? excludeBots = null, CancellationToken? cancellationToken = null)
     => await GetAsync<User[]>($"users/lookup", cancellationToken,
     [
-      .. ids.Select(x => ("ids[]", Uri.EscapeDataString(x))),
+      .. ids.Select(x => ("ids[]", $"@{x}")),
       ("exclude_bots", excludeBots)
     ], json => json["users"]);
 }

--- a/osu.NET/Endpoints/Users.cs
+++ b/osu.NET/Endpoints/Users.cs
@@ -249,4 +249,32 @@ public partial class OsuApiClient
       .. ids.Select(x => ("ids[]", x)),
       ("exclude_bots", excludeBots)
     ], json => json["users"]);
+
+  /// <summary>
+  /// Returns all users with the specified IDs, up to 50. If a user ID could not be found, it is skipped.
+  /// <br/><br/>
+  /// This endpoint does not include any statistics. If you need this information,
+  /// use <see cref="GetUsersAsync(int[], bool?, CancellationToken?)"/> with a higher ratelimit cost.
+  /// <br/><br/>
+  /// API notes:
+  /// <list type="bullet">
+  /// <item>Includes <see cref="User.Country"/></item>
+  /// <item>Includes <see cref="User.Cover"/></item>
+  /// <item>Includes <see cref="User.Groups"/></item>
+  /// <item>Does *not* include <see cref="User.Statistics"/> or <see cref="User.RulesetStatistics"/></item>
+  /// </list>
+  /// API docs:<br/>
+  /// <a href="https://osu.ppy.sh/docs/index.html#get-users"/>
+  /// </summary>
+  /// <param name="ids">The user IDs.</param>
+  /// <param name="excludeBots">Optional. Bool whether bot users should be ignored.</param>
+  /// <param name="cancellationToken">Optional. The cancellation token for aborting the request.</param>
+  /// <returns>The users with the specified IDs.</returns>
+  [CanReturnApiError()]
+  public async Task<ApiResult<User[]>> LookupUsersAsync(string[] ids, bool? excludeBots = null, CancellationToken? cancellationToken = null)
+    => await GetAsync<User[]>($"users/lookup", cancellationToken,
+    [
+      .. ids.Select(x => ("ids[]", x)),
+      ("exclude_bots", excludeBots)
+    ], json => json["users"]);
 }

--- a/osu.NET/OsuApiClient.cs
+++ b/osu.NET/OsuApiClient.cs
@@ -6,7 +6,6 @@ using osu.NET.Helpers;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
-using System.Web;
 
 namespace osu.NET;
 
@@ -171,7 +170,7 @@ public partial class OsuApiClient(IOsuAccessTokenProvider accessTokenProvider, O
         _ => value!.ToString()!
       };
 
-      url += $"{HttpUtility.UrlEncode(key)}={HttpUtility.UrlEncode(valueStr)}&";
+      url += $"{Uri.EscapeDataString(key)}={Uri.EscapeDataString(valueStr)}&";
     }
 
     return url.TrimEnd('?').TrimEnd('&');


### PR DESCRIPTION
## Summary

Added a method overload that accepts `string[]` instead of `int[]` in `LookupUsersAsync`.

## Motivation

On the osu-web project, this endpoint accepts both strings and numbers to be passed in as arguments. This allows easier bulk user lookup with usernames.

https://github.com/ppy/osu-web/blob/a59efd5a950f655ec0988f84c3833896fb158be1/app/Http/Controllers/Users/LookupController.php#L40